### PR TITLE
Update TEA specification to v0.3.0 for publishing

### DIFF
--- a/openapi/tea_spec_v0.2.1.yaml
+++ b/openapi/tea_spec_v0.2.1.yaml
@@ -1,0 +1,260 @@
+openapi: 3.0.3
+info:
+  title: OpenAPI Transparency Exchange API specification 
+  description: |-
+    This is an OpenAPI specification of the Transparency Exchange API specification - Project Koala.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 0.2.0
+paths:
+  /product/{tei}:
+    get:
+      tags:
+        - product
+      summary: Display Product
+      description: Show product with all leafs
+      operationId: displayProduct
+      parameters:
+        - name: tei
+          in: path
+          required: true
+          description: TEI unique product index
+          schema:
+            type: string
+        - name: visibility
+          in: query
+          description: Used to specify whether we list public or private components
+          required: false
+          schema:
+            type: string
+            enum:
+              - PUBLICONLY
+              - ALLAVAILABLE
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Product'
+  /leaf/{tei}:
+    get:
+      tags:
+        - leaf
+      summary: Display leaf
+      description: Show all collection versions for leaf
+      operationId: displayLeaf
+      parameters:
+        - name: tei
+          in: path
+          required: true
+          description: TEI unique leaf index
+          schema:
+            type: string
+        - name: visibility
+          in: query
+          description: Used to specify whether we list public or private components
+          required: false
+          schema:
+            type: string
+            enum:
+              - PUBLICONLY
+              - ALLAVAILABLE
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CollectionEl'
+  /collection/{collectionId}:
+    get:
+      tags:
+        - collection
+      summary: Display Collection
+      description: Show collection contents
+      operationId: displayCollection
+      parameters:
+        - name: collectionId
+          in: path
+          required: true
+          description: id assigned in the system to the specific collection as returned by collection element
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Collection'
+components:
+  schemas:
+    Product:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          example: 5d0f59cd-5787-4e42-8e22-a2343cf19dd8
+        name:
+          type: string
+          example: Awesome Product
+        lifecycle:
+          type: array
+          items:
+            $ref: '#/components/schemas/Lifecycle'
+        leafs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Leaf'
+    Leaf:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          example: 5d0f59cd-5787-4e42-8e22-a2343cf19dd8
+        name:
+          type: string
+          example: Awesome Leaf
+        tei:
+          type: string
+          example: urn:tei:uuid:products.example.com:d4d9f54a-abcf-11ee-ac79-1a52914d44b1?version=3
+        version:
+          type: string
+          example: 0.1.0
+        lifecycle:
+          type: array
+          items:
+            $ref: '#/components/schemas/Lifecycle'
+    CollectionEl:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          example: 5d0f59cd-5787-4e42-8e22-a2343cf19dd8
+        version:
+          type: string
+          example: 0.1.0
+    Collection:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          example: 5d0f59cd-5787-4e42-8e22-a2343cf19dd8
+        identities:
+          type: array
+          items:
+            $ref: '#/components/schemas/Identity'
+        version:
+          type: string
+          example: 7.50.3-1
+        created:
+          type: string
+          format: date-time
+        artifacts:
+          type: array
+          items:
+            $ref: '#/components/schemas/Artifact'
+        lifecycle:
+          type: array
+          items:
+            $ref: '#/components/schemas/Lifecycle'
+    Artifact:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          example: 5d0f59cd-5787-4e42-8e22-a2343cf19dd8
+        displayIdentifier:
+          type: string
+          example: pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie
+        identities:
+          type: array
+          items:
+            $ref: '#/components/schemas/Identity'
+        type:
+          type: string
+          enum:
+            - BOM
+            - ATTESTATION
+            - VDR
+            - VEX
+            - OTHER
+        version:
+          type: string
+          example: 1
+        downloadLinks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+        date:
+          type: string
+          format: date-time
+        inventoryTypes:
+          type: array
+          items:
+            type: string
+            enum:
+              - SOFTWARE
+              - HARDWARE
+              - CRYPTOGRAPHY
+              - SERVICE
+              - VULNERABILITY
+        bomFormat:
+          type: string
+          example: CycloneDX
+    Lifecycle:
+      type: object
+      properties:
+        event:
+          type: string
+          enum:
+            - FIRST_MENTION
+            - ALPHA_TESTING
+            - BETA_TESTING
+            - RELEASE_CANDIDATE
+            - GENERAL_AVAILABILITY
+            - END_OF_DEVELOPMENT
+            - END_OF_SALES
+            - END_OF_SUPPORT
+            - END_OF_LIFE
+        date:
+          type: string
+          format: date-time
+    Identity:
+      type: object
+      properties:
+        type:
+          type: string
+          example: PURL
+        identifier:
+          type: string
+          example: pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie
+    Link:
+      type: object
+      properties:
+        url:
+          type: string
+          example: https://mysite.com/mysbom.json 
+        content:
+          type: string
+          enum:
+            - OCI
+            - PLAIN_JSON
+            - OCTET_STREAM
+            - PLAIN_XML
+        public:
+          description: Used to indicate whether the url is public or private
+          type: boolean

--- a/openapi/tea_spec_v0.3.0.yaml
+++ b/openapi/tea_spec_v0.3.0.yaml
@@ -1,0 +1,530 @@
+openapi: 3.0.3
+info:
+  title: Transparency Exchange API Specification
+  description: |-
+    This is an OpenAPI specification of the Transparency Exchange API (TEA) - Project Koala.
+    
+    The Transparency Exchange API allows for the discovery, retrieval, and publication of software transparency artifacts such as SBOMs, VEX, and other related documents.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 0.3.0
+servers:
+  - url: https://tea.example.com/0.3.0/
+    description: Production Transparency Exchange API
+paths:
+  /.well-known/tei/{tei}:
+    get:
+      tags:
+        - discovery
+      summary: TEA Discovery
+      description: Discover TEA endpoint for a given TEI
+      operationId: teaDiscovery
+      parameters:
+        - name: tei
+          in: path
+          required: true
+          description: Transparency Exchange Identifier (TEI) URN
+          schema:
+            type: string
+            pattern: '^urn:tei:[a-z]+:[a-zA-Z0-9.-]+:[a-zA-Z0-9-]+$'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoveryResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /product/{tei}:
+    get:
+      tags:
+        - product
+      summary: Display Product
+      description: Show product with all leafs
+      operationId: displayProduct
+      parameters:
+        - name: tei
+          in: path
+          required: true
+          description: Transparency Exchange Identifier (TEI) URN
+          schema:
+            type: string
+            pattern: '^urn:tei:[a-z]+:[a-zA-Z0-9.-]+:[a-zA-Z0-9-]+$'
+        - name: visibility
+          in: query
+          description: Used to specify whether we list public or private components
+          required: false
+          schema:
+            type: string
+            enum:
+              - PUBLICONLY
+              - ALLAVAILABLE
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/perPageParam'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedProductResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /leaf/{tei}:
+    get:
+      tags:
+        - leaf
+      summary: Display leaf
+      description: Show all collection versions for leaf
+      operationId: displayLeaf
+      parameters:
+        - name: tei
+          in: path
+          required: true
+          description: Transparency Exchange Identifier (TEI) URN
+          schema:
+            type: string
+            pattern: '^urn:tei:[a-z]+:[a-zA-Z0-9.-]+:[a-zA-Z0-9-]+$'
+        - name: visibility
+          in: query
+          description: Used to specify whether we list public or private components
+          required: false
+          schema:
+            type: string
+            enum:
+              - PUBLICONLY
+              - ALLAVAILABLE
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/perPageParam'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCollectionElResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /collection/{collectionId}:
+    get:
+      tags:
+        - collection
+      summary: Display Collection
+      description: Show collection contents
+      operationId: displayCollection
+      parameters:
+        - name: collectionId
+          in: path
+          required: true
+          description: ID assigned in the system to the specific collection as returned by collection element
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      tags:
+        - collection
+      summary: Update Collection
+      description: Update an existing collection
+      operationId: updateCollection
+      parameters:
+        - name: collectionId
+          in: path
+          required: true
+          description: ID assigned in the system to the specific collection
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Collection'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+        - collection
+      summary: Delete Collection
+      description: Delete an existing collection
+      operationId: deleteCollection
+      parameters:
+        - name: collectionId
+          in: path
+          required: true
+          description: ID assigned in the system to the specific collection
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successful operation
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /collection:
+    post:
+      tags:
+        - collection
+      summary: Create Collection
+      description: Create a new collection
+      operationId: createCollection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Collection'
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /artifact:
+    post:
+      tags:
+        - artifact
+      summary: Publish Artifact Information
+      description: Publish information about an artifact to a collection
+      operationId: publishArtifactInfo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ArtifactInfo'
+      responses:
+        '201':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtifactInfo'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /search:
+    get:
+      tags:
+        - search
+      summary: Search Products and Collections
+      description: Search for products and collections based on various criteria
+      operationId: searchProductsCollections
+      parameters:
+        - name: query
+          in: query
+          description: Search query string
+          required: false
+          schema:
+            type: string
+        - name: type
+          in: query
+          description: Type of items to search for
+          required: false
+          schema:
+            type: string
+            enum: [product, collection, all]
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/perPageParam'
+      responses:
+        '200':
+          description: Successful operation
+          headers:
+            Link:
+              $ref: '#/components/headers/Link'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+components:
+  parameters:
+    pageParam:
+      name: page
+      in: query
+      description: Page number for pagination
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    perPageParam:
+      name: per_page
+      in: query
+      description: Number of items per page
+      required: false
+      schema:
+        type: integer
+        minimum: 10
+        maximum: 100
+        default: 10
+
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    DiscoveryResponse:
+      type: object
+      properties:
+        apiEndpoint:
+          type: string
+          format: uri
+        apiVersion:
+          type: string
+
+    PaginatedProductResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Product'
+        page:
+          type: integer
+        perPage:
+          type: integer
+        totalItems:
+          type: integer
+        totalPages:
+          type: integer
+
+    PaginatedCollectionElResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CollectionEl'
+        page:
+          type: integer
+        perPage:
+          type: integer
+        totalItems:
+          type: integer
+        totalPages:
+          type: integer
+
+    SearchResponse:
+      type: object
+      properties:
+        products:
+          type: array
+          items:
+            $ref: '#/components/schemas/Product'
+        collections:
+          type: array
+          items:
+            $ref: '#/components/schemas/Collection'
+        page:
+          type: integer
+        perPage:
+          type: integer
+        totalItems:
+          type: integer
+        totalPages:
+          type: integer
+
+    Product:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        lifecycle:
+          type: array
+          items:
+            $ref: '#/components/schemas/Lifecycle'
+        leafs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Leaf'
+
+    Leaf:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        tei:
+          type: string
+          pattern: '^urn:tei:[a-z]+:[a-zA-Z0-9.-]+:[a-zA-Z0-9-]+$'
+        version:
+          type: string
+        lifecycle:
+          type: array
+          items:
+            $ref: '#/components/schemas/Lifecycle'
+
+    CollectionEl:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        version:
+          type: string
+
+    Collection:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        product:
+          $ref: '#/components/schemas/ProductInfo'
+        version:
+          type: integer
+        author:
+          $ref: '#/components/schemas/Author'
+        artifacts:
+          type: array
+          items:
+            $ref: '#/components/schemas/Artifact'
+        lifecycle:
+          type: array
+          items:
+            $ref: '#/components/schemas/Lifecycle'
+
+    ProductInfo:
+      type: object
+      properties:
+        name:
+          type: string
+        version:
+          type: string
+        releaseDate:
+          type: string
+          format: date
+        teiId:
+          type: string
+          pattern: '^urn:tei:[a-z]+:[a-zA-Z0-9.-]+:[a-zA-Z0-9-]+$'
+
+    Author:
+      type: object
+      properties:
+        name:
+          type: string
+        org:
+          type: string
+        email:
+          type: string
+          format: email
+
+    Artifact:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        author:
+          $ref: '#/components/schemas/Author'
+        formats:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArtifactFormat'
+
+    ArtifactFormat:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        bomIdentifier:
+          type: string
+        mediaType:
+          type: string
+        category:
+          type: string
+        url:
+          type: string
+          format: uri
+        sigUrl:
+          type: string
+          format: uri
+        hash:
+          type: string
+        size:
+          type: integer
+
+    ArtifactInfo:
+      type: object
+      properties:
+        collections:
+          type: array
+          items:
+            type: string
+        artifact:
+          $ref: '#/components/schemas/Artifact'
+
+    Lifecycle:
+      type: object
+      properties:
+        event:
+          type: string
+          enum:
+            - FIRST_MENTION
+            - ALPHA_TESTING
+            - BETA_TESTING
+            - RELEASE_CANDIDATE
+            - GENERAL_AVAILABILITY
+            - END_OF_DEVELOPMENT
+            - END_OF_SALES
+            - END_OF_SUPPORT
+            - END_OF_LIFE
+        date:
+          type: string
+          format: date-time
+
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string

--- a/openapi/tea_spec_v0.3.0.yaml
+++ b/openapi/tea_spec_v0.3.0.yaml
@@ -254,9 +254,6 @@ paths:
       responses:
         '200':
           description: Successful operation
-          headers:
-            Link:
-              $ref: '#/components/headers/Link'
           content:
             application/json:
               schema:


### PR DESCRIPTION
I've made the following changes to address requirements as I understand them in the proposals outlines in [CycloneDX/transparency-exchange-api](https://github.com/CycloneDX/transparency-exchange-api) and likely wrong in many ways still:

- Added a `/.well-known/tei/{tei}` endpoint for TEA discovery.
- Added a `/artifact` endpoint for publishing artifact information to collections.
- Added a `/search` endpoint for searching products and collections.
- Added `PUT` and `DELETE` methods to the `/collection/{collectionId}` endpoint, and a `POST` method to `/collection` for managing collections.
- Added more detailed error responses using a common Error schema.
- Added pagination support using the Link header and additional query parameters, following common practices.
- Expanded content types in the ArtifactFormat schema to accommodate various formats.

This updated specification should address the points raised in use cases and WG recordings, while maintaining the core functionality of the Transparency Exchange API.

The specification now includes mechanisms for discovery, artifact publishing, searching, and collection management, with improved error handling and pagination support.